### PR TITLE
Remove TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,3 @@ This repository uses a number of technologies, including:
 
 - [Babel](https://babeljs.io)
 - [Webpack](https://webpack.js.org)
-- [Travis CI](https://travis-ci.org/)


### PR DESCRIPTION
This PR removes the reference to TravisCI within `README.md`. As I understand it, the reference to TravisCI was added prematurely and it has never been used within this repository.